### PR TITLE
Enable macOS builds on Apple silicon

### DIFF
--- a/ioctl-sys/src/platform/macos.rs
+++ b/ioctl-sys/src/platform/macos.rs
@@ -1,4 +1,4 @@
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 mod consts {
     #[doc(hidden)]
     pub const NONE: u8 = 1;
@@ -12,7 +12,7 @@ mod consts {
     pub const DIRBITS: u8 = 3;
 }
 
-#[cfg(not(target_arch = "x86_64"))]
+#[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
 use this_arch_not_supported;
 
 #[doc(hidden)]


### PR DESCRIPTION
Hi, thank you for your great crate. We rely on it for some other crate that we want to build for the new Apple chips, and it would be great to have this small fix merged.