### PR TITLE
Add ioctl!(read0 ...)

### DIFF
--- a/ioctl-sys/examples/smoke.rs
+++ b/ioctl-sys/examples/smoke.rs
@@ -6,8 +6,18 @@ ioctl!(none drm_ioctl_set_master with b'd', 0x1e);
 ioctl!(read ev_get_version with b'E', 0x01; u32);
 ioctl!(write ev_set_repeat with b'E', 0x03; [u32; 2]);
 
+ioctl!(try none drm_ioctl_set_master2 with b'd', 0x1e);
+ioctl!(try read ev_get_version2 with b'E', 0x01; u32);
+ioctl!(try read0 ev_get_version3 with b'E', 0x01; u32);
+ioctl!(try write ev_set_repeat2 with b'E', 0x03; [u32; 2]);
+
 fn main() {
     let mut x = 0;
     let ret = unsafe { ev_get_version(0, &mut x) };
     println!("returned {}, x = {}", ret, x);
+    let mut x2 = 0;
+    let ret2 = unsafe { ev_get_version2(0, &mut x2) };
+    println!("returned {:?}, x = {}", ret2, x2);
+    let ret3 = unsafe { ev_get_version3(0) };
+    println!("returned {:?}", ret3);
 }

--- a/ioctl-sys/src/lib.rs
+++ b/ioctl-sys/src/lib.rs
@@ -12,6 +12,15 @@ extern "C" {
     pub fn ioctl(fd: c_int, req: c_ulong, ...) -> c_int;
 }
 
+#[doc(hidden)]
+pub fn check_res(res: c_int) -> std::io::Result<()> {
+    if res < 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
 #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "android")))]
 use platform_not_supported;
 


### PR DESCRIPTION
This version of the macro would start with a zeroed struct, call the ioctl, and return the struct if the ioctl succeeded, otherwise a proper error. Because that's usually what you want to do.

It's an untested draft, let me know what you think!