### PR TITLE
Add OpenBSD support

### DIFF
--- a/ioctl-sys/src/lib.rs
+++ b/ioctl-sys/src/lib.rs
@@ -1,10 +1,10 @@
 use std::os::raw::{c_int, c_ulong};
 
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "android"))]
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "openbsd", target_os = "android"))]
 #[macro_use]
 mod platform;
 
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "android"))]
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "openbsd", target_os = "android"))]
 pub use platform::*;
 
 extern "C" {
@@ -21,7 +21,7 @@ pub fn check_res(res: c_int) -> std::io::Result<()> {
     }
 }
 
-#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "android")))]
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "openbsd", target_os = "android")))]
 use platform_not_supported;
 
 #[cfg(doctest)]

--- a/ioctl-sys/src/platform/mod.rs
+++ b/ioctl-sys/src/platform/mod.rs
@@ -11,6 +11,10 @@ mod consts;
 #[path = "macos.rs"]
 mod consts;
 
+#[cfg(target_os = "openbsd")]
+#[path = "openbsd.rs"]
+mod consts;
+
 #[doc(hidden)]
 pub use self::consts::*;
 

--- a/ioctl-sys/src/platform/openbsd.rs
+++ b/ioctl-sys/src/platform/openbsd.rs
@@ -1,0 +1,19 @@
+#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+mod consts {
+    #[doc(hidden)]
+    pub const NONE: u8 = 1;
+    #[doc(hidden)]
+    pub const READ: u8 = 2;
+    #[doc(hidden)]
+    pub const WRITE: u8 = 4;
+    #[doc(hidden)]
+    pub const SIZEBITS: u8 = 13;
+    #[doc(hidden)]
+    pub const DIRBITS: u8 = 3;
+}
+
+#[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
+use this_arch_not_supported;
+
+#[doc(hidden)]
+pub use self::consts::*;


### PR DESCRIPTION
The crate is now able to compile on OpenBSD. It's basically just a copy of the MacOS variant.

I tried a few ioctls on OpenBSD so far and they are working properly with this implementation.