### PR TITLE
Add support for riscv64

### DIFF
--- a/ioctl-sys/src/platform/linux.rs
+++ b/ioctl-sys/src/platform/linux.rs
@@ -31,7 +31,8 @@ mod consts {
     target_arch = "x86",
     target_arch = "arm",
     target_arch = "x86_64",
-    target_arch = "aarch64"
+    target_arch = "aarch64",
+    target_arch = "riscv64"
 )))]
 use this_arch_not_supported;
 
@@ -40,7 +41,8 @@ use this_arch_not_supported;
     target_arch = "x86",
     target_arch = "arm",
     target_arch = "x86_64",
-    target_arch = "aarch64"
+    target_arch = "aarch64",
+    target_arch = "riscv64"
 ))]
 mod consts {
     #[doc(hidden)]

--- a/ioctls/etc/process_ioctls.py
+++ b/ioctls/etc/process_ioctls.py
@@ -21,6 +21,7 @@ consts = {
     "x86_64": { "NONE": 0, "READ": 2, "WRITE": 1, "SIZEBITS": 14, "DIRBITS": 2},
     "arm": { "NONE": 0, "READ": 2, "WRITE": 1, "SIZEBITS": 14, "DIRBITS": 2},
     "aarch64": { "NONE": 0, "READ": 2, "WRITE": 1, "SIZEBITS": 14, "DIRBITS": 2},
+    "riscv64": { "NONE": 0, "READ": 2, "WRITE": 1, "SIZEBITS": 14, "DIRBITS": 2},
 }
 
 ioc_consts = {


### PR DESCRIPTION
`riscv64` is using the same asm-generic ioctl.h as `aarch64`.

Builds fine and all tests pass on HiFive Unmatched.